### PR TITLE
add TLS option to login

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ services:
       IMGU2_SMTP_USERNAME: "mailer@example.com"
       IMGU2_SMTP_PASSWORD: "example_password"
       IMGU2_SMTP_HOST: "example.com"
-      IMGU2_SMTP_PORT: "25"
+      IMGU2_SMTP_AUTH_TLS: "true"  # 使用 TLS
+      IMGU2_SMTP_PORT: "587"
       IMGU2_SMTP_SENDER: "mailer@example.com"
       IMGU2_JWT_SECRET: "example_secret_string"
     volumes:

--- a/README_en_us.md
+++ b/README_en_us.md
@@ -74,6 +74,7 @@ services:
     environment:
       IMGU2_SMTP_USERNAME: "mailer@example.com"
       IMGU2_SMTP_PASSWORD: "example_password"
+      IMGU2_SMTP_AUTH_TLS: "true"  # use TLS
       IMGU2_SMTP_HOST: "example.com"
       IMGU2_SMTP_PORT: "25"
       IMGU2_SMTP_SENDER: "mailer@example.com"

--- a/services/mailer.go
+++ b/services/mailer.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
 	"strconv"
@@ -34,12 +35,31 @@ func (mailer) SendMail(to string, subject string, content string) error {
 	username := os.Getenv("IMGU2_SMTP_USERNAME")
 	password := os.Getenv("IMGU2_SMTP_PASSWORD")
 	host := os.Getenv("IMGU2_SMTP_HOST")
+	auth_tls, err := strconv.ParseBool(os.Getenv("IMGU2_SMTP_AUTH_TLS"))
+	if err != nil {
+		return fmt.Errorf("sendmail: invalid IMGU2_SMTP_AUTH_TLS: %s", os.Getenv("IMGU2_SMTP_AUTH_TLS"))
+	}
 	port, err := strconv.Atoi(os.Getenv("IMGU2_SMTP_PORT"))
 	if err != nil {
 		return fmt.Errorf("sendmail: invalid IMGU2_SMTP_PORT: %s", os.Getenv("IMGU2_SMTP_PORT"))
 	}
 
-	client, err := mail.NewClient(host, mail.WithPort(port), mail.WithSMTPAuth(mail.SMTPAuthPlain), mail.WithUsername(username), mail.WithPassword(password))
+	var tlsConfig mail.Option
+	tls_ := tls.Config{InsecureSkipVerify: false, ServerName: host}
+	if auth_tls {
+		tlsConfig = mail.WithTLSConfig(&tls_)
+	} else {
+		tlsConfig = nil
+	}
+
+	client, err := mail.NewClient(
+		host,
+		mail.WithPort(port),
+		tlsConfig,
+		mail.WithSMTPAuth(mail.SMTPAuthLogin),
+		mail.WithUsername(username),
+		mail.WithPassword(password),
+	)
 	if err != nil {
 		return fmt.Errorf("sendmail: %w", err)
 	}


### PR DESCRIPTION
新增 TLS 選項，同時將驗證方式從 `Plain` 更改為 `Login`（使用 Offie365 E3 測試）