### PR TITLE
fix verify captcha template typo

### DIFF
--- a/templates/html/verify_email.html
+++ b/templates/html/verify_email.html
@@ -6,7 +6,7 @@
 
     {{template "csrf" .csrf_token}}
 
-    {{template "hcaptcha" .}}
+    {{template "captcha" .}}
     
     <button class="btn btn-outline-primary">{{tr "send_verification_email_to"}} {{.user.Email}}</button>
     <p><a href="/dashboard/account">{{tr "click_to_change_email"}}</a></p>


### PR DESCRIPTION
```log
time=2024-03-14T09:20:49.911+08:00 level=ERROR msg="render template" err="render template: html/template:verify_email.html:9:15: no such template \"hcaptcha\"" name=verify_email data="map[csrf_token:b6b4e2646760cf60 git_commit:DEVELOPMENT title:imgu2 dev user:0x14000098960 version:v0.0.0]"
```